### PR TITLE
pico-sdk: Rename adc_read() to adc_read_pico()

### DIFF
--- a/ChangeLog.zephyr.md
+++ b/ChangeLog.zephyr.md
@@ -1,0 +1,12 @@
+# The List of changes to fit zephyr.
+
+Need to take care to not break these changes when updating pico-sdk.
+
+## Patch List:
+  - [#3] pico-sdk: Rename adc_read() to pico_adc_read()
+    - src/rp2_common/hardware_adc/include/hardware/adc.h
+  - [#2] pico-sdk: Patch occurrences of KHZ/MHZ to PICO_KHZ/PICO_MHZ
+    - src/rp2_common/hardware_clocks/clocks.c
+    - src/rp2_common/hardware_clocks/include/hardware/clocks.h
+    - src/rp2_common/hardware_pll/pll.c
+    - src/rp2_common/hardware_xosc/xosc.c

--- a/src/rp2_common/hardware_adc/include/hardware/adc.h
+++ b/src/rp2_common/hardware_adc/include/hardware/adc.h
@@ -130,7 +130,7 @@ static inline void adc_set_temp_sensor_enabled(bool enable) {
  *
  * \return Result of the conversion.
  */
-static inline uint16_t adc_read(void) {
+static inline uint16_t pico_adc_read(void) {
     hw_set_bits(&adc_hw->cs, ADC_CS_START_ONCE_BITS);
 
     while (!(adc_hw->cs & ADC_CS_READY_BITS))


### PR DESCRIPTION
adc_read() that defined in adc.h of PICO-SDK conflicts with zephyr's ADC API.
Rename it to avoid compile errors.

PICO-SDK doesn't reference adc_read() from itself,
so we can change the definition only.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>