### PR TITLE
Adapting the hardware_timer API to Zephyr

### DIFF
--- a/ChangeLog.zephyr.md
+++ b/ChangeLog.zephyr.md
@@ -3,6 +3,11 @@
 Need to take care to not break these changes when updating pico-sdk.
 
 ## Patch List:
+  - [#7]   pico-sdk: hardware_timer: Don't add irq handler to interrupt vector
+    - src/rp2_common/hardware_timer/timer.c
+  - [#6] pico-sdk: hardware_timer: Add argument to irq handler to handle userdata
+    - src/rp2_common/hardware_timer/include/hardware/timer.h 
+    - src/rp2_common/hardware_timer/timer.c
   - [#5] pico-sdk: Rename is_irq_enabled() to pico_is_irq_enabled()
     - src/rp2_common/hardware_irq/include/hardware/irq.h
     - src/rp2_common/hardware_irq/irq.c

--- a/src/rp2_common/hardware_timer/include/hardware/timer.h
+++ b/src/rp2_common/hardware_timer/include/hardware/timer.h
@@ -121,10 +121,13 @@ static inline bool time_reached(absolute_time_t t) {
 /*! Callback function type for hardware alarms
  *  \ingroup hardware_timer
  *
+ * Modification on the porting to Zephyr:
+ * Add parameter argument to enable referencing user data
+ *
  * \param alarm_num the hardware alarm number
  * \sa hardware_alarm_set_callback()
  */
-typedef void (*hardware_alarm_callback_t)(uint alarm_num);
+typedef void (*hardware_alarm_callback_t)(uint alarm_num, void *data);
 
 /*! \brief cooperatively claim the use of this hardware alarm_num
  *  \ingroup hardware_timer
@@ -214,6 +217,13 @@ void hardware_alarm_cancel(uint alarm_num);
  * @param alarm_num the hardware alarm number
  */
 void hardware_alarm_force_irq(uint alarm_num);
+
+/**
+ * Modification on the porting to Zephyr:
+ * Publish as API.
+ * Add parameter argument to enable referencing user data
+ */
+void hardware_alarm_irq_handler(void *dev);
 #ifdef __cplusplus
 }
 #endif

--- a/src/rp2_common/hardware_timer/timer.c
+++ b/src/rp2_common/hardware_timer/timer.c
@@ -150,29 +150,23 @@ void hardware_alarm_irq_handler(void* data) {
     }
 }
 
+/**
+ * Modification on the porting to Zephyr:
+ * Don't add irq handler to interrupt vector in this function.
+ */
 void hardware_alarm_set_callback(uint alarm_num, hardware_alarm_callback_t callback) {
     // todo check current core owner
     //  note this should probably be subsumed by irq_set_exclusive_handler anyway, since that
     //  should disallow IRQ handlers on both cores
     check_hardware_alarm_num_param(alarm_num);
-    uint irq_num = harware_alarm_irq_number(alarm_num);
     spin_lock_t *lock = spin_lock_instance(PICO_SPINLOCK_ID_TIMER);
     uint32_t save = spin_lock_blocking(lock);
     if (callback) {
-        if (hardware_alarm_irq_handler != irq_get_vtable_handler(irq_num)) {
-            // note that set_exclusive will silently allow you to set the handler to the same thing
-            // since it is idempotent, which means we don't need to worry about locking ourselves
-            irq_set_exclusive_handler(irq_num, hardware_alarm_irq_handler);
-            irq_set_enabled(irq_num, true);
-            // Enable interrupt in block and at processor
-            hw_set_bits(&timer_hw->inte, 1u << alarm_num);
-        }
+        hw_set_bits(&timer_hw->inte, 1u << alarm_num);
         alarm_callbacks[alarm_num] = callback;
     } else {
         alarm_callbacks[alarm_num] = NULL;
         timer_callbacks_pending &= (uint8_t)~(1u << alarm_num);
-        irq_remove_handler(irq_num, hardware_alarm_irq_handler);
-        irq_set_enabled(irq_num, false);
     }
     spin_unlock(lock, save);
 }

--- a/src/rp2_common/hardware_timer/timer.c
+++ b/src/rp2_common/hardware_timer/timer.c
@@ -110,7 +110,12 @@ static inline uint harware_alarm_irq_number(uint alarm_num) {
     return TIMER_IRQ_0 + alarm_num;
 }
 
-static void hardware_alarm_irq_handler(void) {
+/**
+ * Modification on the porting to Zephyr:
+ * Add parameter argument to enable referencing user data
+ * Publish as API.
+ */
+void hardware_alarm_irq_handler(void* data) {
     // Determine which timer this IRQ is for
     uint alarm_num = __get_current_exception() - VTABLE_FIRST_IRQ - TIMER_IRQ_0;
     check_hardware_alarm_num_param(alarm_num);
@@ -141,7 +146,7 @@ static void hardware_alarm_irq_handler(void) {
     spin_unlock(lock, save);
 
     if (callback) {
-        callback(alarm_num);
+        callback(alarm_num, data);
     }
 }
 


### PR DESCRIPTION
I created PR https://github.com/zephyrproject-rtos/zephyr/pull/57134 to support the rpi_pico timer feature.
This PR adapts pico-sdk's hardware_timer implementation for use with Zephyr.
Change the pico-sdk not to modify the interrupt vector because  Zephyr uses it.