### PR TITLE
pico-sdk: Avoid using 'typeof()' operator

### DIFF
--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -299,7 +299,7 @@ static void flash_devinfo_update_field(uint16_t wdata, uint16_t mask) {
     // Boot RAM does not support exclusives, but does support RWTYPE SET/CLR/XOR (with byte
     // strobes). Can't use hw_write_masked because it performs a 32-bit write.
     io_rw_16 *devinfo = flash_devinfo_ptr();
-    *hw_xor_alias(devinfo) = (*devinfo ^ wdata) & mask;
+    *(io_rw_16*)hw_xor_alias_untyped(devinfo) = (*devinfo ^ wdata) & mask;
 }
 
 // This is a RAM function because may be called during flash programming to enable save/restore of


### PR DESCRIPTION
C99 doesn't support the `typeof()` operator used in Pico-SDK. So we need to rewrite using `hw_xor_alias` code with `hw_xor_alias_untyped()`.
