### PR TITLE
pico-sdk: adapt for the sha256 driver to Zephyr

### DIFF
--- a/ChangeLog.zephyr.md
+++ b/ChangeLog.zephyr.md
@@ -3,6 +3,9 @@
 Need to take care to not break these changes when updating pico-sdk.
 
 ## Patch List:
+  - [#11] pico-sdk: Comment out parts that are not needed in Zephyr
+    - src/rp2_common/pico_sha256/include/pico/sha256.h
+    - src/rp2_common/pico_sha256/sha256.c
   - [#10] pico-sdk: Switch to picolibc
     - src/rp2040/boot_stage2/CMakeLists.txt
     - src/rp2040/boot_stage2/boot_stage2.ld

--- a/src/rp2_common/pico_sha256/include/pico/sha256.h
+++ b/src/rp2_common/pico_sha256/include/pico/sha256.h
@@ -7,8 +7,10 @@
 #ifndef _PICO_SHA256_H
 #define _PICO_SHA256_H
 
+#if !defined(__ZEPHYR__)
 #include "pico/time.h"
 #include "hardware/dma.h"
+#endif
 #include "hardware/sha256.h"
 
 /** \file pico/sha256.h
@@ -54,10 +56,13 @@ typedef struct pico_sha256_state {
         uint32_t word;
         uint8_t bytes[4];
     } cache;
+#if !defined(__ZEPHYR__)
     dma_channel_config config;
+#endif
     size_t total_data_size;
 } pico_sha256_state_t;
 
+#if !defined(__ZEPHYR__)
 /*! \brief Release the internal lock on the SHA-256 hardware
  *  \ingroup pico_sha256
  *
@@ -109,6 +114,7 @@ int pico_sha256_start_blocking_until(pico_sha256_state_t *state, enum sha256_end
 static inline int pico_sha256_start_blocking(pico_sha256_state_t *state, enum sha256_endianness endianness, bool use_dma) {
     return pico_sha256_start_blocking_until(state, endianness, use_dma, at_the_end_of_time);
 }
+#endif
 
 /*! \brief Add byte data to be SHA-256 calculation
  *  \ingroup pico_sha256
@@ -127,6 +133,7 @@ static inline int pico_sha256_start_blocking(pico_sha256_state_t *state, enum sh
  */
 void pico_sha256_update(pico_sha256_state_t *state, const uint8_t *data, size_t data_size_bytes);
 
+#if !defined(__ZEPHYR__)
 /*! \brief Add byte data to be SHA-256 calculation
  *  \ingroup pico_sha256
  *
@@ -152,6 +159,11 @@ void pico_sha256_update_blocking(pico_sha256_state_t *state, const uint8_t *data
  * @param out The SHA-256 checksum
  */
 void pico_sha256_finish(pico_sha256_state_t *state, sha256_result_t *out);
+#endif
+
+#if defined(__ZEPHYR__)
+void pico_sha256_write_padding(pico_sha256_state_t *state);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/rp2_common/pico_sha256/sha256.c
+++ b/src/rp2_common/pico_sha256/sha256.c
@@ -11,12 +11,15 @@
 #include "hardware/sha256.h"
 #include "pico/bootrom/lock.h"
 #include "pico/sha256.h"
+#if !defined(__ZEPHYR__)
 #include "pico/time.h"
+#endif
 
 // We add one 0x80 byte, then 8 bytes for the size
 #define SHA256_PADDING_DATA_BYTES 9
 #define SHA256_BLOCK_SIZE_BYTES 64
 
+#if !defined(__ZEPHYR__)
 bool __weak pico_sha256_lock(pico_sha256_state_t *state) {
     if (!bootrom_try_acquire_lock(BOOTROM_LOCK_SHA_256))
         return false;
@@ -74,8 +77,10 @@ int pico_sha256_start_blocking_until(pico_sha256_state_t *state, enum sha256_end
     } while (true);
     return rc;
 }
+#endif
 
 static void write_to_hardware(pico_sha256_state_t *state, const uint8_t *data, size_t data_size_bytes) {
+#if !defined(__ZEPHYR__)
     if (state->channel >= 0) {
         dma_channel_wait_for_finish_blocking(state->channel);
         assert(!sha256_err_not_ready());
@@ -89,6 +94,7 @@ static void write_to_hardware(pico_sha256_state_t *state, const uint8_t *data, s
             true
         );
     } else {
+#endif
         if (!state->cache_used && !(((uintptr_t)data)&3u)) {
             GCC_Like_Pragma("GCC diagnostic ignored \"-Wcast-align\"")
             const uint32_t *data32 = (const uint32_t *)data;
@@ -109,7 +115,9 @@ static void write_to_hardware(pico_sha256_state_t *state, const uint8_t *data, s
                 sha256_put_word(state->cache.word);
             }
         }
+#if !defined(__ZEPHYR__)
     }
+#endif
 }
 
 static void update_internal(pico_sha256_state_t *state, const uint8_t *data, size_t data_size_bytes) {
@@ -144,12 +152,14 @@ void pico_sha256_update(pico_sha256_state_t *state, const uint8_t *data, size_t 
     update_internal(state, data, data_size_bytes);
 }
 
+#if !defined(__ZEPHYR__)
 void pico_sha256_update_blocking(pico_sha256_state_t *state, const uint8_t *data, size_t data_size_bytes) {
     update_internal(state, data, data_size_bytes);
     if (state->channel >= 0) {
         dma_channel_wait_for_finish_blocking(state->channel);
     }
 }
+#endif
 
 // write the SHA-256 padding to hardware
 static void write_padding(pico_sha256_state_t *state) {
@@ -170,6 +180,7 @@ static void write_padding(pico_sha256_state_t *state) {
     update_internal(state, (uint8_t*)&size, sizeof(uint64_t)); // last write
 }
 
+#if !defined(__ZEPHYR__)
 void pico_sha256_finish(pico_sha256_state_t *state, sha256_result_t *out) {
     assert(state->locked);
     // pass NULL to abandon the current hash in case of an error
@@ -188,4 +199,9 @@ void pico_sha256_finish(pico_sha256_state_t *state, sha256_result_t *out) {
         state->channel  = -1;
     }
     pico_sha256_unlock(state);
+}
+#endif
+
+void pico_sha256_write_padding(pico_sha256_state_t *state) {
+	write_padding(state);
 }


### PR DESCRIPTION
Comment out unused DMA-related code and add wrappers to expose
internal functions.